### PR TITLE
Base path for GitHub Pages deployment is set. Added '/Todo-App/'

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,11 @@ import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "url";
 import { defineConfig } from "vite";
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [legacy(), react()],
+  base: "/Todo-App/",
   resolve: {
     alias: {
-      // for TypeScript path alias import like : @/x/y/z
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },


### PR DESCRIPTION
Base path for GitHub Pages deployment is set. Added '/Todo-App/' to vite config and ensured that correct asset is loading on GitHub Pages. Routing issues in production build will fix because of it.